### PR TITLE
Fix #59 Setting "Find By = Test Id" to locate a page element causes codegen to fail

### DIFF
--- a/common/src/codegen/utils/locator-generator-dotnet/testId.ts
+++ b/common/src/codegen/utils/locator-generator-dotnet/testId.ts
@@ -3,6 +3,6 @@ import { escapeStr } from "../../utils/stringUtils";
 
 export default (params: ILocatorTemplateParam) => {
   return params.hasParams
-    ? `this._page.Locator(string.Format(\"xpath=\\*[@data-testid='${escapeStr(params.locatorStr)}']\", parameters))`
-    : `this._page.Locator(\"xpath=\\*[@data-testid='${escapeStr(params.locatorStr)}']\")`;
+    ? `this._page.GetByTestId(string.Format("${escapeStr(params.locatorStr)}", parameters))`
+    : `this._page.GetByTestId("${escapeStr(params.locatorStr)}")`;
 };


### PR DESCRIPTION
#59 