### PR TITLE
Fix #57 Setting "Find By = Attribute" to locate a page element causes codegen to fail

### DIFF
--- a/common/src/codegen/utils/locator-generator-dotnet/attribute.ts
+++ b/common/src/codegen/utils/locator-generator-dotnet/attribute.ts
@@ -2,6 +2,6 @@ import { ILocatorTemplateParam } from "../../types";
 import { escapeStr } from "../../utils/stringUtils";
 
 export default (params: ILocatorTemplateParam) => {
-  const [attr, value] = params.locatorStr.split("=");
+  const [attr = "", value = ""] = params.locatorStr.split("=");
   return `this._page.Locator("//*[@${escapeStr(attr)} = '${escapeStr(value)}']");`;
 };


### PR DESCRIPTION
 #57  Fix `attribute` locator with default empty strings